### PR TITLE
Fix JQL query by parent epic

### DIFF
--- a/app/services/jira_api_client_service.rb
+++ b/app/services/jira_api_client_service.rb
@@ -27,7 +27,7 @@ class JiraApiClientService
   end
 
   def query_epic_issues(project_key, epic_key, labels = [])
-    jql_string = "project = #{project_key} AND parent = #{epic_key}"
+    jql_string = "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key})"
     jql_string += " AND labels in (#{labels.join(',')})" if labels.present?
     request_query_params = { query: { jql: jql_string } }
     response = HTTParty.get("#{BASE_URL}/search", request_params.merge(request_query_params))

--- a/spec/services/jira_api_client_service_spec.rb
+++ b/spec/services/jira_api_client_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe JiraApiClientService do
           headers: { 'Accept' => 'application/json' },
           basic_auth: [ENV.fetch('JIRA_USERNAME'), ENV.fetch('JIRA_API_TOKEN')],
           query: {
-            jql: "project = #{project_key} AND parent = #{epic_key}"
+            jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key})"
           }
         )
       end
@@ -129,7 +129,8 @@ RSpec.describe JiraApiClientService do
           headers: { 'Accept' => 'application/json' },
           basic_auth: [ENV.fetch('JIRA_USERNAME'), ENV.fetch('JIRA_API_TOKEN')],
           query: {
-            jql: "project = #{project_key} AND parent = #{epic_key} AND labels in (#{labels.join(',')})"
+            jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key}) " \
+                 "AND labels in (#{labels.join(',')})"
           }
         )
       end
@@ -157,7 +158,7 @@ RSpec.describe JiraApiClientService do
           headers: { 'Accept' => 'application/json' },
           basic_auth: [ENV.fetch('JIRA_USERNAME'), ENV.fetch('JIRA_API_TOKEN')],
           query: {
-            jql: "project = #{project_key} AND parent = #{epic_key}"
+            jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key})"
           }
         )
       end

--- a/spec/support/mocks/jira_api_mocker.rb
+++ b/spec/support/mocks/jira_api_mocker.rb
@@ -29,7 +29,7 @@ class JiraApiMocker
 
   def stub_query_epic_issues(project_key, epic_key)
     url = "#{BASE_URL}/search"
-    query_params = { query: { jql: "project = #{project_key} AND parent = #{epic_key}" } }
+    query_params = { query: { jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key})" } }
     stub_request(url, request_params(query_params)).to_return(
       status: 200,
       body: JiraApiResponses.query_epic_issues_response_body(project_key, epic_key)
@@ -39,7 +39,8 @@ class JiraApiMocker
   def stub_query_epic_issues_with_labels(project_key, epic_key, labels)
     url = "#{BASE_URL}/search"
     query_params = { query: {
-      jql: "project = #{project_key} AND parent = #{epic_key} AND labels in (#{labels.join(',')})"
+      jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key}) " \
+           "AND labels in (#{labels.join(',')})"
     } }
     stub_request(url, request_params(query_params)).to_return(
       status: 200,
@@ -49,7 +50,7 @@ class JiraApiMocker
 
   def stub_query_epic_issues_with_custom_story_points_field(project_key, epic_key)
     url = "#{BASE_URL}/search"
-    query_params = { query: { jql: "project = #{project_key} AND parent = #{epic_key}" } }
+    query_params = { query: { jql: "project = #{project_key} AND (parent = #{epic_key} OR parentepic = #{epic_key})" } }
     stub_request(url, request_params(query_params)).to_return(
       status: 200,
       body: JiraApiResponses.query_epic_issues_with_custom_story_points_field_response_body(project_key, epic_key)


### PR DESCRIPTION
A user of the application reported that their board was reflecting 0 issues under their epics.

We detected that somehow the relationship between Issue and Epic was using `parentepic` instead of `parent` field.

Also we found that they were using a custom column for story points, so it has to be added to the ENV var.